### PR TITLE
Fix API request body schema for GoDaddy domains availability check

### DIFF
--- a/lookup.js
+++ b/lookup.js
@@ -51,14 +51,15 @@ const available = {};
 tlds.forEach((tld) => (available[tld] = []));
 
 async function checkDomainsBatch(domains) {
-  const url = `https://api.ote-godaddy.com/v1/domains/available`;
+  const url = `https://api.ote-godaddy.com/v1/domains/available?checkType=FAST`;
   const response = await fetch(url, {
     method: "POST",
     headers: {
       Authorization: `sso-key ${GODADDY_API_KEY}:${GODADDY_API_SECRET}`,
       "Content-Type": "application/json",
+      Accept: "application/json",
     },
-    body: JSON.stringify({ domains, checkType: "FAST" }),
+    body: JSON.stringify(domains),
   });
 
   if (!response.ok) {


### PR DESCRIPTION
Changed the request body from { domains: [...] } to just [...] array. GoDaddy API expects a plain array of domain strings, not an object.

This fixes the "Request body doesn't fulfill schema" error.





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GoDaddy domain availability request by sending a plain array of domain strings in the JSON body and adding Accept: application/json. This resolves the “Request body doesn't fulfill schema” error and restores batch checks.

<sup>Written for commit bbcf9173fe114a5c4ed8839b09bfea76f007d64d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





